### PR TITLE
fix: 修复调用createFromData参数错误的问题

### DIFF
--- a/ScreenCapture/Painter.cpp
+++ b/ScreenCapture/Painter.cpp
@@ -61,11 +61,11 @@ void Painter::shotScreen()
     canvasImage = new BLImage(w, h, BL_FORMAT_PRGB32);
     prepareImage = new BLImage(w, h, BL_FORMAT_PRGB32);
     bgImage = new BLImage();
-    bgImage->createFromData(w, h, BL_FORMAT_PRGB32, bgPixels, stride, BL_DATA_ACCESS_RW,[](void* impl, void* externalData, void* userData) {
+    bgImage->createFromData(w, h, BL_FORMAT_PRGB32, bgPixels, stride, [](void* impl, void* externalData, void* userData) {
         delete[] externalData;
     });
     boardImage = new BLImage();
-    boardImage->createFromData(w, h, BL_FORMAT_PRGB32, boardPixels, stride, BL_DATA_ACCESS_RW, [](void* impl, void* externalData, void* userData) {
+    boardImage->createFromData(w, h, BL_FORMAT_PRGB32, boardPixels, stride, [](void* impl, void* externalData, void* userData) {
         delete[] externalData; //todo
     });
     paintCtx = new BLContext();


### PR DESCRIPTION

error: 错误 C2664 “BLResult BLImage::createFromData(int,int,BLFormat,void *,intptr_t,BLDestroyExternalDataFunc,void *) noexcept”: 无法将参数 6 从“BLDataAccessFlags”转换为“BLDestroyExternalDataFunc” ScreenCapture

https://github.com/xland/ScreenCapture/issues/4