### PR TITLE
fix: screenshot clipboard history and tray menu dismissal

### DIFF
--- a/ScreenCapture/Tray.cpp
+++ b/ScreenCapture/Tray.cpp
@@ -202,7 +202,10 @@ void Tray::onTrayRightClick()
 	AppendMenu(menu, MF_STRING, exitMsg, Lang::get(L"tray.exit").c_str());
 	POINT pt;
 	GetCursorPos(&pt); //获取鼠标位置
+	// Give the popup foreground ownership so it closes when focus moves elsewhere.
+	SetForegroundWindow(hwnd);
 	TrackPopupMenuEx(menu, TPM_RIGHTBUTTON,  pt.x, pt.y, hwnd, nullptr);
+	PostMessage(hwnd, WM_NULL, 0, 0);
 	DestroyMenu(menu);
 }
 

--- a/ScreenCapture/Util.cpp
+++ b/ScreenCapture/Util.cpp
@@ -56,7 +56,15 @@ void Util::saveToClipboard(int& w, int& h, BYTE* data)
     bih->biBitCount    = 32;
     bih->biCompression = BI_RGB;
     bih->biSizeImage   = imgBytes;
-    CopyMemory(p + sizeof(BITMAPINFOHEADER), data, imgBytes);
+    BYTE* pixels = p + sizeof(BITMAPINFOHEADER);
+    CopyMemory(pixels, data, imgBytes);
+    // GDI (GetDIBits) does not populate the alpha channel, leaving alpha bytes at 0.
+    // Windows 10/11 Clipboard History (Win+V) can treat 32bpp bitmaps with alpha=0
+    // as fully transparent, making copied screenshots appear blank in history.
+    // Force alpha to 255 (opaque) so the copied image remains visible.
+    for (DWORD i = 3; i < imgBytes; i += 4) {
+        pixels[i] = 0xFF;
+    }
     GlobalUnlock(hGlobal);
     if (!SetClipboardData(CF_DIB, hGlobal)) {
         GlobalFree(hGlobal);


### PR DESCRIPTION
Background issue: after copying a screenshot to the clipboard, Windows Clipboard History may fail to track/save it correctly, so the newly copied screenshot does not appear in `Win + V`. Also, after opening the system tray context menu, clicking outside the menu does not close it. Both issues make core screenshot and tray interactions feel unreliable, so they should be fixed.

### Summary
Fixes two Windows integration issues:
- Copied screenshots not being tracked/saved correctly by Windows Clipboard History
- System tray context menu not closing when clicking outside

### Implementation
- Forces the alpha channel of 32bpp bitmap data to `0xFF` before writing `CF_DIB` data to the clipboard, preventing Windows 10/11 Clipboard History from failing to record screenshots because all alpha bytes are `0`.
- Calls `SetForegroundWindow(hwnd)` before showing the tray popup menu so the menu gets proper foreground ownership.
- Posts `WM_NULL` after `TrackPopupMenuEx` returns to ensure the popup menu closes correctly after losing focus.

### Files changed
- Modified: `ScreenCapture/Util.cpp`
- Modified: `ScreenCapture/Tray.cpp`
- 2 files, +12 / -1 lines

### Verified
- Builds clean on Release|x64, 0 errors
- Recommended manual checks:
  1. Capture a screenshot, open `Win + V`, and confirm the newly copied screenshot appears in Clipboard History
  2. Right-click the system tray icon, click outside the context menu, and confirm the menu closes automatically

<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/8d8bc484-064b-42a1-a663-d03aed3a9836" />

<img width="350" height="195" alt="temp" src="https://github.com/user-attachments/assets/3f57e937-e6d5-48dd-a723-615b75a5eedf" />


